### PR TITLE
Potential fix for code scanning alert no. 25: XML external entity expansion

### DIFF
--- a/xsd_importer.py
+++ b/xsd_importer.py
@@ -18,7 +18,8 @@ DCT = Namespace("http://purl.org/dc/terms/")
 def parse_xsd_content(xsd_content):
     """Parse XSD content string and return the root element."""
     try:
-        root = etree.fromstring(xsd_content.encode('utf-8'))
+        parser = etree.XMLParser(resolve_entities=False)
+        root = etree.fromstring(xsd_content.encode('utf-8'), parser=parser)
         return root
     except Exception as e:
         print(f"Error parsing XSD content: {e}")


### PR DESCRIPTION
Potential fix for [https://github.com/I14Y-ch/structure_generator/security/code-scanning/25](https://github.com/I14Y-ch/structure_generator/security/code-scanning/25)

To prevent XML external entity (XXE) attacks, the fix is to disable entity expansion when parsing untrusted XML with lxml. In this project, the user-provided XML content is parsed in `parse_xsd_content`. The best way to fix this is to instantiate an lxml XML parser with `resolve_entities=False`, and pass it as an argument to `etree.fromstring`. This disables entity expansion while allowing normal XML parsing. 
Only the file `xsd_importer.py` and the function `parse_xsd_content` need to be modified. No additional changes are required to the import statements because `lxml.etree.XMLParser` is already available.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
