### PR TITLE
Potential fix for code scanning alert no. 24: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -4366,7 +4366,11 @@ def load_graph():
     if not filename:
         return jsonify({"error": "Filename is required"}), 400
         
-    filepath = os.path.join('data', filename)
+    # Prevent path traversal: normalize and check that path stays in 'data'
+    base_dir = os.path.abspath('data')
+    filepath = os.path.normpath(os.path.join(base_dir, filename))
+    if not filepath.startswith(base_dir + os.sep):
+        return jsonify({"error": "Invalid filename"}), 400
     
     if not os.path.exists(filepath):
         return jsonify({"error": "File not found"}), 404


### PR DESCRIPTION
Potential fix for [https://github.com/I14Y-ch/structure_generator/security/code-scanning/24](https://github.com/I14Y-ch/structure_generator/security/code-scanning/24)

To fix this issue, we need to ensure that any user-supplied `filename` cannot be used to perform path traversal or reference files outside the intended `data` directory. The best way is to normalize the constructed path using `os.path.normpath`, then check that the resulting path is still underneath the intended root directory (`data`). This blocks attempts to escape (via `../`, absolute paths, etc.) and guarantees access is restricted to files inside `data`. Optionally, we may also block absolute paths and further sanitize filenames (e.g., using `werkzeug.utils.secure_filename` if more restrictions are desired).

Specifically, in the `load_graph` function in app.py, lines constructing and checking `filepath` should be updated:
- Use `os.path.normpath(os.path.join('data', filename))`
- Check that the result starts with the absolute path to `data` (using `os.path.abspath`)
- If the path is invalid (e.g., outside the `data` folder or absolute), return an error.
- These changes should be local to the function; only referenced code can be changed.
- Import `os` (already present).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
