### PR TITLE
Potential fix for code scanning alert no. 30: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -5861,7 +5861,7 @@ def import_xsd():
         import traceback
         print(f"Error importing XSD: {str(e)}")
         print(traceback.format_exc())
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "An internal error occurred."}), 500
 
 @app.route('/api/nodes/<node_id>/convert-to-dataset', methods=['POST'])
 def convert_to_dataset(node_id):


### PR DESCRIPTION
Potential fix for [https://github.com/I14Y-ch/structure_generator/security/code-scanning/30](https://github.com/I14Y-ch/structure_generator/security/code-scanning/30)

To fix the issue, you should replace the response containing `{"error": str(e)}` with a more generic error message, such as `{"error": "An internal error occurred."}` for the client. However, retain the existing server-side logging of the exception and stack trace details via `print()`, as seen on lines 5862 and 5863. This ensures that developers still receive debug information, but it won’t be exposed externally. Only modify the code at and around line 5864 in `app.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
